### PR TITLE
docs(examples): add simple example

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,0 +1,33 @@
+import Express from 'express';
+import bodyParser from 'body-parser';
+import { graphqlExpress, graphiqlExpress } from 'apollo-server-express';
+import { grampsExpress } from '../src';
+
+const app = Express();
+
+app.use(
+  '/graphql',
+
+  // Required for POST requests.
+  bodyParser.json(),
+
+  // Create a combined (but empty) schema and context.
+  grampsExpress(),
+
+  // Use the data sources and context object from GrAMPS.
+  graphqlExpress(req => ({
+    schema: req.gramps.schema,
+    context: req.gramps.context,
+  })),
+);
+
+app.use(
+  '/graphiql',
+  graphiqlExpress({
+    endpointURL: '/graphql',
+  }),
+);
+
+app.listen(2551, () => {
+  console.log('Visit http://localhost:2551/graphiql in your browser.');
+});

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint src/**/*.js",
     "test": "npm run lint --silent && npm run test:unit --silent",
     "test:unit": "NODE_ENV=test LOG4JS_LEVEL='OFF' jest --coverage",
+    "example:simple": "BABEL_DISABLE_CACHE=1 nodemon -e js,json,graphql examples/simple.js --exec babel-node",
     "semantic-release": "semantic-release pre && npm publish --access public && semantic-release post"
   },
   "dependencies": {


### PR DESCRIPTION
This is an example of a GrAMPS server with no data sources. Still need to add additional examples (data sources from npm, local data sources, mixed).