### PR TITLE
Proposal to remove request property

### DIFF
--- a/src/dev/app.js
+++ b/src/dev/app.js
@@ -11,21 +11,21 @@ const enableMockData =
 
 app.use(bodyParser.json());
 
-app.use(
-  grampsExpress({
-    dataSources: [],
-    enableMockData,
-    extraContext: req => ({ req }),
-  }),
-);
-
+const { fromRequestContext } = grampsExpress({
+  dataSources: [],
+  enableMockData,
+  extraContext: req => ({ req }),
+});
 app.all(
   '/graphql',
-  graphqlExpress(req => ({
-    schema: req.gramps.schema,
-    context: req.gramps.context,
-    formatError: req.gramps.formatError,
-  })),
+  graphqlExpress(req => {
+    const gramps = fromRequestContext(req, req.res);
+    return {
+      schema: gramps.schema,
+      context: gramps.context,
+      formatError: gramps.formatError,
+    };
+  }),
 );
 
 app.get(

--- a/src/gramps.js
+++ b/src/gramps.js
@@ -79,7 +79,7 @@ export default function grampsExpress(
     });
   }
 
-  return (req, res, next) => {
+  function fromRequestContext(req, res) {
     const context = sources.reduce(
       (models, source) => ({
         ...models,
@@ -88,13 +88,18 @@ export default function grampsExpress(
       extraContext(req, res),
     );
 
-    req.gramps = {
+    return {
       schema,
       context,
       formatError: formatError(logger),
       ...apolloOptions.graphqlExpress,
     };
+  }
 
+  const middleware = (req, res, next) => {
+    req.gramps = fromRequestContext(req, res);
     next();
   };
+
+  return Object.assign(middleware, { fromRequestContext });
 }

--- a/test/gramps-test.js
+++ b/test/gramps-test.js
@@ -10,6 +10,28 @@ describe('GrAMPS', () => {
     jest.clearAllMocks();
   });
 
+  describe('non-middleware usage', () => {
+    it('properly configures a schema when called with no options', () => {
+      const mockReq = {};
+      const gramps = grampsExpress().fromRequestContext(mockReq, {});
+
+      expect(cfg.addMockFunctions).toHaveBeenCalled();
+      expect(cfg.getSchema).toHaveBeenCalledWith({
+        sources: [],
+        logger: console,
+        options: {},
+      });
+
+      expect(gramps).toEqual(
+        expect.objectContaining({
+          context: {},
+          formatError: expect.any(Function),
+          schema: expect.any(Object),
+        }),
+      );
+    });
+  });
+
   describe('grampsExpress()', () => {
     it('properly configures a schema when called with no options', () => {
       /*

--- a/yarn.lock
+++ b/yarn.lock
@@ -2407,7 +2407,7 @@ graphql-tools@^2.5.0:
     deprecated-decorator "^0.1.6"
     uuid "^3.1.0"
 
-graphql@^0.11.3, graphql@^0.11.7:
+graphql@^0.11.3:
   version "0.11.7"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.11.7.tgz#e5abaa9cb7b7cccb84e9f0836bf4370d268750c6"
   dependencies:


### PR DESCRIPTION
It seemed a bit awkward to have a middleware just to attach a property to the request and then read it in the next one. This allows the user to opt into a non-middleware interface that just creates the gramps object from a `req`/`res` pair.

This is just a super quick POC. Let me know if you're interested in exploring this direction and I might get around to actually flesh this out / document it / etc..