### PR TITLE
fix: inherit environment variables

### DIFF
--- a/bin/gramps.js
+++ b/bin/gramps.js
@@ -133,5 +133,8 @@ const source = getDataSource(rootDir, argv.dataSourceDir);
 // Move into the root Node directory and start the service.
 shell.cd(rootDir);
 shell.exec(`node dist/dev/server.js`, {
-  env: { GRAMPS_MODE: env, GQL_DATA_SOURCES: source },
+  env: Object.assign({}, process.env, {
+    GRAMPS_MODE: env,
+    GQL_DATA_SOURCES: source,
+  }),
 });


### PR DESCRIPTION
Permit environment variables in data sources when running via
gramps command.