### PR TITLE
test(dataloader): add test for dataloaders

### DIFF
--- a/test/helpers/GraphQLConnector-test.js
+++ b/test/helpers/GraphQLConnector-test.js
@@ -202,6 +202,22 @@ describe('GraphQLConnector', () => {
         'https://example.com/test/endpoint',
       ]);
     });
+
+    it.skip('uses the DataLoader to eliminate redundant requests', async () => {
+      const tc = new TestConnector();
+
+      tc.apiBaseUri = 'https://example.com';
+
+      tc.load = jest.fn(() => Promise.resolve([{}]));
+
+      await tc.get('/test/endpoint');
+      await tc.get('/test/endpoint');
+
+      expect(tc.load).toHaveBeenCalledTimes(1);
+      expect(tc.load).toHaveBeenCalledWith([
+        'https://example.com/test/endpoint',
+      ]);
+    });
   });
 
   describe('post()', () => {


### PR DESCRIPTION
Add failing unit test case from https://github.com/gramps-graphql/gramps-express/issues/47 discussion. I think this is what you asked for.

I'd like to add an integration tests around dataloader behavior, but looking at https://github.com/gramps-graphql/gramps-express/issues/30 it seems like you have plans and I should wait. It would be nice to have an integration tests against the two external datasources in the tests, where graphql queries and the responses can be validated.